### PR TITLE
feat: support Avaya Vantage 3

### DIFF
--- a/src/registry/models/identity.py
+++ b/src/registry/models/identity.py
@@ -7,14 +7,22 @@ from registry.models.endpoint import Endpoint
 
 class IdentityManager(models.Manager):
     _avaya_j_regex = re.compile(r"AVAYA/(J\d{3})-(?:\d\.?)+ \(MAC:([abcdef0-9]{12})\)$")
+    _avaya_vantage3_regex = re.compile(
+        r"Avaya/Vantage/.+-(K175).*\(MAC:([ABCDEFabcdef0-9]{12})\)$"
+    )
 
     def _avaya_jseries(self, ua: str) -> "Identity" or None:
         if match := self._avaya_j_regex.search(ua):
             return Identity(model=match.group(1), mac=match.group(2))
 
+    def _avaya_vantage3(self, ua: str) -> "Identity" or None:
+        if match := self._avaya_vantage3_regex.search(ua):
+            return Identity(model=match.group(1), mac=match.group(2))
+
     def identify(self, ua: str) -> "Identity" or None:
         for fn in [
             self._avaya_jseries,
+            self._avaya_vantage3,
         ]:
             identity = fn(ua)
             if identity:

--- a/src/registry/tests/test_identity.py
+++ b/src/registry/tests/test_identity.py
@@ -35,6 +35,16 @@ class TestIdentity(TestCase):
                 ua="Mozilla/4.0 (compatible; MSIE 6.0) AVAYA/J179-4.2.0 (MAC:c41f3ae55689)",
                 want=Identity(model="J179", mac="c41f3ae55689"),
             ),
+            MatchCase(
+                name="vantage3",
+                ua="Avaya/Vantage/3.2.0.1.9035-K175CW0A (MAC:C81FEADF8A4A)",
+                want=Identity(model="K175", mac="C81FEADF8A4A"),
+            ),
+            MatchCase(
+                name="vantage3",
+                ua="Avaya/Vantage/3.1.0-K175CW0A (MAC:C81FBE4E8A4A)",
+                want=Identity(model="K175", mac="C81FBE4E8A4A"),
+            ),
         ]
 
         for case in cases:
@@ -49,6 +59,10 @@ class TestIdentity(TestCase):
             NoMatchCase(
                 name="jseries-wrong-model",
                 ua="Mozilla/4.0 (compatible; MSIE 6.0) AVAYA/R134-4.2.0 (MAC:c41f3ae55689)",
+            ),
+            NoMatchCase(
+                name="vantage3-wrong-model",
+                ua="Avaya/Vantage/3.1.0-K195CW0A (MAC:C81FBE4E8A4A)",
             ),
         ]
 


### PR DESCRIPTION
The user agent of these phones can now be parsed to obtain their identity and serve the proper file.